### PR TITLE
files : reorganize + add llama-cpp-cuda-default

### DIFF
--- a/llama.cpp/cuda-default/Dockerfile
+++ b/llama.cpp/cuda-default/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 RUN git clone https://github.com/ggerganov/llama.cpp -b master --depth 1 .
 
 RUN cmake -S . -B build \
-    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined \
     -DLLAMA_CURL=ON \
     -DLLAMA_SERVER_VERBOSE=OFF \
     -DLLAMA_DISABLE_LOGS=1 \


### PR DESCRIPTION
Apply the changes from https://github.com/ggerganov/llama.cpp/pull/9213 in order to build shared libraries. Uncompressed image size goes from 2.9GB -> 2.4GB